### PR TITLE
build: tests working without feature flag

### DIFF
--- a/malachite-base/Cargo.toml
+++ b/malachite-base/Cargo.toml
@@ -38,6 +38,7 @@ test_build = ["gnuplot", "time", "clap"]
 bin_build = ["walkdir", "test_build"]
 
 [dev-dependencies]
+malachite-base = { path = ".", features = ["test_build"] }
 maplit = "1.0.2"
 
 [package.metadata.docs.rs]

--- a/malachite-nz/Cargo.toml
+++ b/malachite-nz/Cargo.toml
@@ -30,6 +30,9 @@ serde_json = { version = "^1.0.32", optional = true }
 num = { version = "0.4.0", optional = true, features = ["serde"] }
 rug = { version = "1.16.0", default-features = false, optional = true, features = ["integer", "serde"] }
 
+[dev-dependencies]
+malachite-nz = { path = ".", features = ["test_build"] }
+
 [features]
 32_bit_limbs = []
 enable_serde = ["serde"]

--- a/malachite-q/Cargo.toml
+++ b/malachite-q/Cargo.toml
@@ -30,6 +30,9 @@ serde_json = { version = "^1.0.32", optional = true }
 num = { version = "0.4.0", optional = true, features = ["serde"] }
 rug = { version = "1.16.0", default-features = false, optional = true, features = ["rational", "serde"] }
 
+[dev-dependencies]
+malachite-q = { path = ".", features = ["test_build"] }
+
 [features]
 enable_serde = ["serde", "malachite-nz/enable_serde"]
 32_bit_limbs = ["malachite-nz/32_bit_limbs"]


### PR DESCRIPTION
Enables running the tests with simply `cargo test` instead of `cargo test --features test_build`.

Solution taken from:
https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481