### PR TITLE
Implement `One`, `Two` and `NegativeOne` for `NonZero*` types

### DIFF
--- a/malachite-base/src/num/basic/traits.rs
+++ b/malachite-base/src/num/basic/traits.rs
@@ -65,3 +65,47 @@ impl<T: One + Sized + Zero> Iverson for T {
         }
     }
 }
+
+// Implementation for `NonZero*` types:
+// * `One` and `Two` for both signed and unsigned variants
+// * `NegativeOne` for the signed variant
+macro_rules! impl_non_zero {
+    ($($t:ident),+) => {
+        $(
+            impl One for $t {
+                const ONE: Self = match Self::new(1) {
+                    Some(v) => v,
+                    None => unreachable!("1 is a valid non zero value")
+                };
+            }
+
+            impl Two for $t {
+                const TWO: Self = match Self::new(2) {
+                    Some(v) => v,
+                    None => unreachable!("2 is a valid non zero value")
+                };
+            }
+        )+
+    };
+    ($($u:ident && $i:ident),+) => {
+        $(
+            impl_non_zero!($u, $i);
+
+            impl NegativeOne for $i {
+                const NEGATIVE_ONE: Self = match Self::new(-1) {
+                    Some(v) => v,
+                    None => unreachable!("-1 is a valid non zero value")
+                };
+            }
+        )+
+    }
+}
+
+impl_non_zero!(
+    NonZeroUsize && NonZeroIsize,
+    NonZeroU128 && NonZeroI128,
+    NonZeroU64 && NonZeroI64,
+    NonZeroU32 && NonZeroI32,
+    NonZeroU16 && NonZeroI16,
+    NonZeroU8 && NonZeroI8
+);

--- a/malachite-base/src/num/basic/traits.rs
+++ b/malachite-base/src/num/basic/traits.rs
@@ -75,14 +75,14 @@ macro_rules! impl_non_zero {
             impl One for $t {
                 const ONE: Self = match Self::new(1) {
                     Some(v) => v,
-                    None => unreachable!("1 is a valid non zero value")
+                    None => unreachable!() // 1 is a valid non zero value
                 };
             }
 
             impl Two for $t {
                 const TWO: Self = match Self::new(2) {
                     Some(v) => v,
-                    None => unreachable!("2 is a valid non zero value")
+                    None => unreachable!() // 2 is a valid non zero value
                 };
             }
         )+
@@ -94,7 +94,7 @@ macro_rules! impl_non_zero {
             impl NegativeOne for $i {
                 const NEGATIVE_ONE: Self = match Self::new(-1) {
                     Some(v) => v,
-                    None => unreachable!("-1 is a valid non zero value")
+                    None => unreachable!() // -1 is a valid non zero value
                 };
             }
         )+


### PR DESCRIPTION
Hi there, i'm using your utility traits quite a lot and would like to propose the following implementation for  `NonZero*` types:
* `One` and `Two` for both signed and unsigned variants
* `NegativeOne` for the signed variant