### PR TITLE
Fix `malachite` docs.rs build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,23 +381,24 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "malachite"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-nz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-q 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-base",
+ "malachite-float",
+ "malachite-nz",
+ "malachite-q",
  "serde",
 ]
 
 [[package]]
 name = "malachite-base"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "getrandom",
  "gnuplot",
  "itertools 0.11.0",
- "malachite-base 0.4.0",
+ "malachite-base",
  "maplit",
  "rand",
  "rand_chacha",
@@ -408,41 +409,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "malachite-base"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606a61b226dc58b8b283399b74754460433c193b193f26eaaad92f7966abd72b"
-dependencies = [
- "clap",
- "getrandom",
- "gnuplot",
- "itertools 0.11.0",
- "rand",
- "rand_chacha",
- "ryu",
- "sha3",
- "time",
-]
-
-[[package]]
 name = "malachite-criterion-bench"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-nz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-base",
+ "malachite-nz",
  "num",
  "rug",
 ]
 
 [[package]]
 name = "malachite-float"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "itertools 0.11.0",
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-nz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-q 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-base",
+ "malachite-nz",
+ "malachite-q",
  "num",
  "rug",
  "serde",
@@ -451,27 +435,12 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "embed-doc-image",
  "itertools 0.11.0",
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-nz 0.4.0",
- "num",
- "rug",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "malachite-nz"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863d06218c83cc2269c425186cc15094d6284b1333a1184d0890aecfddb8916b"
-dependencies = [
- "embed-doc-image",
- "itertools 0.11.0",
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-base",
+ "malachite-nz",
  "num",
  "rug",
  "serde",
@@ -480,27 +449,12 @@ dependencies = [
 
 [[package]]
 name = "malachite-q"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "itertools 0.11.0",
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-nz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-q 0.4.0",
- "num",
- "rug",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "malachite-q"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9d3b8d07e463f4eb247259aa69a32b1cd05419a318ca63f9930d5a893cc69f"
-dependencies = [
- "itertools 0.11.0",
- "malachite-base 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "malachite-nz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-base",
+ "malachite-nz",
+ "malachite-q",
  "num",
  "rug",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ members = ['malachite', 'malachite-base', 'malachite-float', 'malachite-nz', 'ma
 resolver = "2"
 
 [workspace.dependencies]
-malachite-base = { version = "0.4.0", path = 'malachite-base' }
-malachite-nz = { version = "0.4.0", path = 'malachite-nz', default_features = false }
-malachite-q = { version = "0.4.0", path = 'malachite-q' }
-malachite-float = { version = "0.4.0", path = 'malachite-q' }
+malachite-base = { version = "0.4.1", path = 'malachite-base' }
+malachite-nz = { version = "0.4.1", path = 'malachite-nz', default_features = false }
+malachite-q = { version = "0.4.1", path = 'malachite-q' }
+malachite-float = { version = "0.4.1", path = 'malachite-q' }
 
 [profile.release]
 lto = true

--- a/malachite-base/Cargo.toml
+++ b/malachite-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "malachite-base"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 rust-version = "1.61.0"
 edition = "2021"

--- a/malachite-criterion-bench/Cargo.toml
+++ b/malachite-criterion-bench/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "malachite-criterion-bench"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 autobenches = false
 edition = "2021"
 
 [dependencies]
-malachite-base = "0.4.0"
-malachite-nz = { version = "0.4.0", default_features = false }
+malachite-base = { version = "0.4.1", path = "../malachite-base" }
+malachite-nz = { version = "0.4.1", path = "../malachite-nz", default_features = false }
 num = "0.4.1"
 rug = { version = "1.21.0", default-features = false, features = ["integer", "serde"] }
 

--- a/malachite-float/Cargo.toml
+++ b/malachite-float/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "malachite-float"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 rust-version = "1.61.0"
 edition = "2021"
@@ -22,9 +22,9 @@ path = "src/bin.rs"
 
 [dependencies]
 itertools = "0.11.0"
-malachite-base = "0.4.0"
-malachite-nz = { version = "0.4.0", features = ["float_helpers"] }
-malachite-q = "0.4.0"
+malachite-base = { version = "0.4.1", path = "../malachite-base" }
+malachite-nz = { version = "0.4.1", path = "../malachite-nz", features = ["float_helpers"] }
+malachite-q = { version = "0.4.1", path = "../malachite-q" }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 
 serde_json = { version = "1.0.105", optional = true }

--- a/malachite-nz/Cargo.toml
+++ b/malachite-nz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "malachite-nz"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 rust-version = "1.61.0"
 edition = "2021"
@@ -23,7 +23,7 @@ path = "src/bin.rs"
 [dependencies]
 embed-doc-image = "0.1.4"
 itertools = "0.11.0"
-malachite-base = "0.4.0"
+malachite-base = { version = "0.4.1", path = "../malachite-base" }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 
 serde_json = { version = "1.0.105", optional = true }

--- a/malachite-q/Cargo.toml
+++ b/malachite-q/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "malachite-q"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 rust-version = "1.61.0"
 edition = "2021"
@@ -22,8 +22,8 @@ path = "src/bin.rs"
 
 [dependencies]
 itertools = "0.11.0"
-malachite-base = "0.4.0"
-malachite-nz = "0.4.0"
+malachite-base = { version = "0.4.1", path = "../malachite-base" }
+malachite-nz = { version = "0.4.1", path = "../malachite-nz" }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 
 serde_json = { version = "1.0.105", optional = true }

--- a/malachite/Cargo.toml
+++ b/malachite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "malachite"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 rust-version = "1.61.0"
 edition = "2021"
@@ -13,10 +13,10 @@ keywords = ["mathematics", "math", "numerics", "bignum"]
 categories = ["mathematics"]
 
 [dependencies]
-malachite-base = "0.4.0"
-malachite-nz = { version = "0.4.0", optional = true }
-malachite-q = { version = "0.4.0", optional = true }
-malachite-float = { version = "0.4.0", optional = true }
+malachite-base = { version = "0.4.0", path = "../malachite-base" }
+malachite-nz = { version = "0.4.1", path = "../malachite-nz", optional = true }
+malachite-q = { version = "0.4.1", path = "../malachite-q", optional = true }
+malachite-float = { version = "0.4.1", path = "../malachite-float", optional = true }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 
 [features]
@@ -29,5 +29,5 @@ floats = [ "malachite-float" ]
 [package.metadata.docs.rs]
 # docs.rs uses a nightly compiler, so by instructing it to use our `doc-images` feature we
 # ensure that it will render any images that we may have in inner attribute documentation.
-features = ["doc-images"]
+features = ["malachite-nz/doc-images"]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]


### PR DESCRIPTION
The `malachite` docs.rs build for 0.4.0 failed because `doc-images` is not a feature: https://docs.rs/crate/malachite/0.4.0/builds/902438

You can confirm this locally,
```shell
cargo +nightly doc -p malachite --features doc-images
```
fails while the following passes
```shell
cargo +nightly doc -p malachite --features malachite-nz/doc-images
```

(i can't test the actual doc.rs build unfortunately)

I had to add `path =` for the local dependencies to fix the local build (these are stripped out by cargo publish).