### PR TITLE
Implement constant conversion for integers and naturals

### DIFF
--- a/malachite-nz/src/integer/conversion/from_natural.rs
+++ b/malachite-nz/src/integer/conversion/from_natural.rs
@@ -25,6 +25,28 @@ impl Integer {
         }
     }
 
+    /// Converts a sign and a [`Natural`] to an [`Integer`], taking the [`Natural`] by value. The
+    /// [`Natural`] becomes the [`Integer`]'s absolute value, and the sign indicates whether the
+    /// [`Integer`] should be non-negative. Unlike [`Integer::from_sign_and_abs`], the [`Natural`]
+    /// is not checked for equality with zero, so the provided sign is used regardless of the
+    /// [`Natural`]'s value.
+    ///
+    /// # Worst-case complexity
+    /// Constant time and additional memory.
+    ///
+    /// # Examples
+    /// ```
+    /// use malachite_nz::platform::Limb;
+    /// use malachite_nz::integer::Integer;
+    /// use malachite_nz::natural::Natural;
+    ///
+    /// assert_eq!(Integer::from_sign_and_abs_unchecked(true, Natural::from_limb(123u32 as Limb)), 123);
+    /// assert_eq!(Integer::from_sign_and_abs_unchecked(false, Natural::from_limb(123u32 as Limb)), -123);
+    /// ```
+    pub const fn from_sign_and_abs_unchecked(sign: bool, abs: Natural) -> Integer {
+        Integer { sign, abs }
+    }
+
     /// Converts a sign and an [`Natural`] to an [`Integer`], taking the [`Natural`] by reference.
     /// The [`Natural`] becomes the [`Integer`]'s absolute value, and the sign indicates whether
     /// the [`Integer`] should be non-negative. If the [`Natural`] is zero, then the [`Integer`]

--- a/malachite-nz/src/natural/conversion/from_primitive_int.rs
+++ b/malachite-nz/src/natural/conversion/from_primitive_int.rs
@@ -138,3 +138,13 @@ impl_from_larger_than_limb_or_usize!(u128);
 impl_from_larger_than_limb_or_usize!(usize);
 
 apply_to_signeds!(impl_signed);
+
+impl Natural {
+    /// Converts a constant [`Limb`](crate#limbs) to a [`Natural`].
+    ///
+    /// # Worst-case complexity
+    /// Constant time.
+    pub const fn from_limb(u: Limb) -> Natural {
+        Natural(Small(u))
+    }
+}

--- a/malachite-nz/tests/integer/conversion/from_natural.rs
+++ b/malachite-nz/tests/integer/conversion/from_natural.rs
@@ -1,5 +1,6 @@
 use malachite_nz::integer::Integer;
 use malachite_nz::natural::Natural;
+use malachite_nz::platform::Limb;
 use malachite_nz::test_util::generators::natural_gen;
 use std::str::FromStr;
 
@@ -21,6 +22,18 @@ fn test_from_natural() {
     test("1000000000000");
     test("4294967295");
     test("4294967296");
+}
+
+#[test]
+fn test_from_natural_unchecked() {
+    const POS: Integer =
+        Integer::from_sign_and_abs_unchecked(true, Natural::from_limb(123u32 as Limb));
+
+    const NEG: Integer =
+        Integer::from_sign_and_abs_unchecked(false, Natural::from_limb(123u32 as Limb));
+
+    assert_eq!(POS, 123);
+    assert_eq!(NEG, -123);
 }
 
 #[test]

--- a/malachite-nz/tests/natural/conversion/from_primitive_int.rs
+++ b/malachite-nz/tests/natural/conversion/from_primitive_int.rs
@@ -4,6 +4,7 @@ use malachite_base::num::conversion::traits::{ConvertibleFrom, ExactFrom, Satura
 use malachite_base::strings::ToDebugString;
 use malachite_base::test_util::generators::{signed_gen, unsigned_gen};
 use malachite_nz::natural::Natural;
+use malachite_nz::platform::Limb;
 use num::BigUint;
 use rug;
 
@@ -199,4 +200,22 @@ fn from_primitive_int_properties() {
 
     apply_fn_to_unsigneds!(unsigned_properties);
     apply_fn_to_signeds!(signed_properties);
+}
+
+#[test]
+fn from_limb_const() {
+    const U8: Natural = Natural::from_limb(129u8 as Limb);
+    assert_eq!(U8, Natural::from(129u8));
+
+    const U16: Natural = Natural::from_limb(32769u16 as Limb);
+    assert_eq!(U16, Natural::from(32769u16));
+
+    const U32: Natural = Natural::from_limb(2147483649u32 as Limb);
+    assert_eq!(U32, Natural::from(2147483649u32));
+
+    #[cfg(not(feature = "32_bit_limbs"))]
+    {
+        const U64: Natural = Natural::from_limb(9223372036854775809u64 as Limb);
+        assert_eq!(U64, Natural::from(9223372036854775809u64));
+    }
 }


### PR DESCRIPTION
This is just a first pass at the idea in #16. Basically, it enables you to write:


```rust
use malachite::{platform::Limb, Integer, Natural};
const SOME_POS_VAL: Integer = Integer::from_sign_and_abs_unchecked(true, Natural::from_limb(65537));
const SOME_NEG_VAL: Integer = Integer::from_sign_and_abs_unchecked(false, Natural::from_limb(65537));
assert_eq!(SOME_POS_VAL, 65537);
assert_eq!(SOME_NEG_VAL, -65537);
```

It's not very complete or ergonomic, but it does work for my use case at least :)