### PR TITLE
Potential optimization for limbs_sub_same_length_*

### DIFF
--- a/malachite-nz/src/natural/arithmetic/sub.rs
+++ b/malachite-nz/src/natural/arithmetic/sub.rs
@@ -176,6 +176,9 @@ pub_crate_test! {limbs_sub(xs: &[Limb], ys: &[Limb]) -> (Vec<Limb>, bool) {
 //
 // This is equivalent to `mpn_sub_n` from `gmp.h`, GMP 6.2.1.
 pub_crate_test! {limbs_sub_same_length_to_out(out: &mut [Limb], xs: &[Limb], ys: &[Limb]) -> bool {
+    let len = xs.len();
+    assert_eq!(len, ys.len());
+    assert!(out.len() >= len);
     let mut carry = 0;
 
     for (out, (&x, &y)) in out.iter_mut().zip(xs.iter().zip(ys.iter())) {
@@ -236,6 +239,7 @@ pub_crate_test! {limbs_sub_greater_to_out(out: &mut [Limb], xs: &[Limb], ys: &[L
 // This is equivalent to `mpn_sub_n` from `gmp.h`, GMP 6.2.1, where the output is written to the
 // first input.
 pub_crate_test! {limbs_sub_same_length_in_place_left(xs: &mut [Limb], ys: &[Limb]) -> bool {
+    assert_eq!(xs.len(), ys.len());
     let mut carry = 0;
 
     for (x, &y) in xs.iter_mut().zip(ys.iter()) {
@@ -294,6 +298,7 @@ pub_crate_test! {limbs_sub_greater_in_place_left(xs: &mut [Limb], ys: &[Limb]) -
 // This is equivalent to `mpn_sub_n` from `gmp.h`, GMP 6.2.1, where the output is written to the
 // second input.
 pub_crate_test! {limbs_sub_same_length_in_place_right(xs: &[Limb], ys: &mut [Limb]) -> bool {
+    assert_eq!(xs.len(), ys.len());
     let mut carry = 0;
 
     for (&x, y) in xs.iter().zip(ys.iter_mut()) {

--- a/malachite-nz/src/natural/arithmetic/sub.rs
+++ b/malachite-nz/src/natural/arithmetic/sub.rs
@@ -116,6 +116,14 @@ pub(crate) fn sub_and_borrow(x: Limb, y: Limb, borrow: &mut bool) -> Limb {
     diff
 }
 
+#[inline]
+pub(crate) fn sub_with_carry(x: Limb, y: Limb, carry: Limb) -> (Limb, Limb) {
+    let result_no_carry = x.wrapping_sub(y);
+    let result = result_no_carry.wrapping_sub(carry);
+    let carry = Limb::from((result_no_carry > x) || (result > result_no_carry));
+    (result, carry)
+}
+
 // Interpreting a two slices of `Limb`s as the limbs (in ascending order) of two `Natural`s,
 // subtracts the second from the first. Returns a pair consisting of the limbs of the result, and
 // whether there was a borrow left over; that is, whether the second `Natural` was greater than the
@@ -171,10 +179,7 @@ pub_crate_test! {limbs_sub_same_length_to_out(out: &mut [Limb], xs: &[Limb], ys:
     let mut carry = 0;
 
     for (out, (&x, &y)) in out.iter_mut().zip(xs.iter().zip(ys.iter())) {
-        let result_no_carry = x.wrapping_sub(y);
-        let result = result_no_carry.wrapping_sub(carry);
-        carry = Limb::from((result_no_carry > x) || (result > result_no_carry));
-        *out = result
+        (*out, carry) = sub_with_carry(x, y, carry);
     }
 
     carry > 0
@@ -234,10 +239,7 @@ pub_crate_test! {limbs_sub_same_length_in_place_left(xs: &mut [Limb], ys: &[Limb
     let mut carry = 0;
 
     for (x, &y) in xs.iter_mut().zip(ys.iter()) {
-        let result_no_carry = (*x).wrapping_sub(y);
-        let result = result_no_carry.wrapping_sub(carry);
-        carry = Limb::from((result_no_carry > *x) || (result > result_no_carry));
-        *x = result
+        (*x, carry) = sub_with_carry(*x, y, carry);
     }
 
     carry > 0
@@ -295,10 +297,7 @@ pub_crate_test! {limbs_sub_same_length_in_place_right(xs: &[Limb], ys: &mut [Lim
     let mut carry = 0;
 
     for (&x, y) in xs.iter().zip(ys.iter_mut()) {
-        let result_no_carry = x.wrapping_sub(*y);
-        let result = result_no_carry.wrapping_sub(carry);
-        carry = Limb::from((result_no_carry > x) || (result > result_no_carry));
-        *y = result
+        (*y, carry) = sub_with_carry(x, *y, carry);
     }
 
     carry > 0


### PR DESCRIPTION
We recently optimized a GCD-heavy application using `malachite` and in doing so, I also profiled parts of `malachite` related to GCD computation. This PR contains an optimization I found for simple subtraction, which cause a significant reduction in runtime of around 43% for large GCDs (at least for `stable-x86_64-pc-windows-msvc`). Basically, I replaced `sub_and_borrow` with a function more closely aligned with GMPs code and tracked the carry as a `Limb` instead of a `bool`.

I am not quite sure why this yields such a large improvement. I tried the same optimization for the corresponding `add`-functions, which I will post as a separate PR, but it yielded much less improvement (only around 4%). The assembly for the `sub`-related functions looks overly convoluted compared to their `add`-counterparts, so there may be some compiler optimizations applied to `add` which for some reason could not be applied for `sub`.

Finally, I would like to mention that there are more usages of `sub_and_borrow` which I did not replace as they did not relate to GCD. If you wish, I can also try replacing those.