### PR TITLE
Potential optimization for limbs_add_same_length_*

### DIFF
--- a/malachite-nz/src/natural/arithmetic/add.rs
+++ b/malachite-nz/src/natural/arithmetic/add.rs
@@ -147,6 +147,15 @@ fn add_and_carry(x: Limb, y: Limb, carry: &mut bool) -> Limb {
     sum
 }
 
+#[inline]
+fn add_with_carry_limb(x: Limb, y: Limb, carry: Limb) -> (Limb, Limb) {
+    let result_no_carry = x.wrapping_add(y);
+    let result = result_no_carry.wrapping_add(carry);
+    let carry = Limb::from((result_no_carry < x) || (result < result_no_carry));
+
+    (result, carry)
+}
+
 // Interpreting two slices of `Limb`s as the limbs (in ascending order) of two `Natural`s, where the
 // first slice is at least as long as the second, returns a `Vec` of the limbs of the sum of the
 // `Natural`s.
@@ -230,10 +239,7 @@ pub_crate_test! {limbs_add_same_length_to_out(out: &mut [Limb], xs: &[Limb], ys:
     let mut carry = 0;
 
     for (out, (&x, &y)) in out.iter_mut().zip(xs.iter().zip(ys.iter())) {
-        let result_no_carry = x.wrapping_add(y);
-        let result = result_no_carry.wrapping_add(carry);
-        carry = Limb::from((result_no_carry < x) || (result < result_no_carry));
-        *out = result
+        (*out, carry) = add_with_carry_limb(x, y, carry);
     }
 
     carry > 0
@@ -361,10 +367,7 @@ pub_crate_test! {limbs_slice_add_same_length_in_place_left(xs: &mut [Limb], ys: 
     let mut carry = 0;
 
     for (x, &y) in xs.iter_mut().zip(ys.iter()) {
-        let result_no_carry = (*x).wrapping_add(y);
-        let result = result_no_carry.wrapping_add(carry);
-        carry = Limb::from((result_no_carry < *x) || (result < result_no_carry));
-        *x = result
+        (*x, carry) = add_with_carry_limb(*x, y, carry);
     }
 
     carry > 0

--- a/malachite-nz/src/natural/arithmetic/add.rs
+++ b/malachite-nz/src/natural/arithmetic/add.rs
@@ -227,11 +227,16 @@ pub_crate_test! {limbs_add_same_length_to_out(out: &mut [Limb], xs: &[Limb], ys:
     let len = xs.len();
     assert_eq!(len, ys.len());
     assert!(out.len() >= len);
-    let mut carry = false;
-    for i in 0..len {
-        out[i] = add_and_carry(xs[i], ys[i], &mut carry);
+    let mut carry = 0;
+
+    for (out, (&x, &y)) in out.iter_mut().zip(xs.iter().zip(ys.iter())) {
+        let result_no_carry = x.wrapping_add(y);
+        let result = result_no_carry.wrapping_add(carry);
+        carry = Limb::from((result_no_carry < x) || (result < result_no_carry));
+        *out = result
     }
-    carry
+
+    carry > 0
 }}
 
 // Interpreting two slices of `Limb`s as the limbs (in ascending order) of two `Natural`s, where the
@@ -353,11 +358,16 @@ pub_crate_test! {
 pub_crate_test! {limbs_slice_add_same_length_in_place_left(xs: &mut [Limb], ys: &[Limb]) -> bool {
     let xs_len = xs.len();
     assert_eq!(xs_len, ys.len());
-    let mut carry = false;
-    for i in 0..xs_len {
-        xs[i] = add_and_carry(xs[i], ys[i], &mut carry);
+    let mut carry = 0;
+
+    for (x, &y) in xs.iter_mut().zip(ys.iter()) {
+        let result_no_carry = (*x).wrapping_add(y);
+        let result = result_no_carry.wrapping_add(carry);
+        carry = Limb::from((result_no_carry < *x) || (result < result_no_carry));
+        *x = result
     }
-    carry
+
+    carry > 0
 }}
 
 // Interpreting two slices of `Limb`s as the limbs (in ascending order) of two `Natural`s, where the


### PR DESCRIPTION
See https://github.com/mhogrefe/malachite/pull/46. This PR is the `add`-counterpart.

I made a separate PR for this one as it seems to have a significantly smaller effect (only around 4% for large GCDs), but the basic idea is the same.