### PR TITLE
Potential optimization for `limbs_mul_greater_to_out_basecase`

### DIFF
--- a/malachite-nz/src/natural/arithmetic/add_mul.rs
+++ b/malachite-nz/src/natural/arithmetic/add_mul.rs
@@ -76,8 +76,7 @@ pub_crate_test! {limbs_slice_add_mul_limb_same_length_in_place_left(
     let mut carry = 0;
 
     for (x, &y) in xs.iter_mut().zip(ys.iter()) {
-        let (product_hi, mut product_lo) =
-            (DoubleLimb::from(y) * DoubleLimb::from(z)).split_in_half();
+        let (product_hi, mut product_lo) = expanding_mul(y, z);
 
         product_lo = (*x).wrapping_add(product_lo);
         let mut add_carry = Limb::from(*x > product_lo);
@@ -102,8 +101,7 @@ pub(crate) fn limbs_slice_add_mul_two_limbs_same_length_in_place_left(
     let mut carry_lo: Limb = 0;
 
     for (x, &y) in xs.iter_mut().zip(ys.iter()) {
-        let (mut product_hi, mut product_lo) =
-            (DoubleLimb::from(y) * DoubleLimb::from(zs[0])).split_in_half();
+        let (mut product_hi, mut product_lo) = expanding_mul(y, zs[0]);
 
         product_lo = (*x).wrapping_add(product_lo);
         let mut add_carry = Limb::from(*x > product_lo);
@@ -115,7 +113,7 @@ pub(crate) fn limbs_slice_add_mul_two_limbs_same_length_in_place_left(
         carry_lo = carry_hi.wrapping_add(carry_lo);
         add_carry = Limb::from(carry_hi > carry_lo);
 
-        (product_hi, product_lo) = (DoubleLimb::from(y) * DoubleLimb::from(zs[1])).split_in_half();
+        (product_hi, product_lo) = expanding_mul(y, zs[1]);
         carry_lo = product_lo.wrapping_add(carry_lo);
         add_carry += Limb::from(product_lo > carry_lo);
         carry_hi = product_hi.wrapping_add(add_carry);
@@ -124,6 +122,10 @@ pub(crate) fn limbs_slice_add_mul_two_limbs_same_length_in_place_left(
     xs[len] = carry_lo;
 
     carry_hi
+}
+
+fn expanding_mul(x: Limb, y: Limb) -> (Limb, Limb) {
+    (DoubleLimb::from(x) * DoubleLimb::from(y)).split_in_half()
 }
 
 // Given the limbs of two `Natural`s x and y, and a limb `z`, computes x + y * z. The lowest limbs

--- a/malachite-nz/src/natural/arithmetic/add_mul.rs
+++ b/malachite-nz/src/natural/arithmetic/add_mul.rs
@@ -90,7 +90,7 @@ pub_crate_test! {limbs_slice_add_mul_limb_same_length_in_place_left(
     carry
 }}
 
-pub(crate) fn limbs_slice_add_mul_two_limbs_same_length_in_place_left(
+pub(crate) fn limbs_slice_add_mul_two_limbs_matching_length_in_place_left(
     xs: &mut [Limb],
     ys: &[Limb],
     zs: [Limb; 2],

--- a/malachite-nz/src/natural/arithmetic/add_mul.rs
+++ b/malachite-nz/src/natural/arithmetic/add_mul.rs
@@ -621,7 +621,7 @@ impl AddMulAssign<Natural, Natural> for Natural {
             (_, Natural(Small(y)), _) => self.add_mul_assign_limb(z, *y),
             (_, _, Natural(Small(z))) => self.add_mul_assign_limb(y, *z),
             (Natural(Large(ref mut xs)), Natural(Large(ref ys)), Natural(Large(ref zs))) => {
-                limbs_add_mul_in_place_left(xs, ys, zs)
+                limbs_add_mul_in_place_left(xs, ys, zs);
             }
         }
     }
@@ -660,7 +660,7 @@ impl<'a> AddMulAssign<Natural, &'a Natural> for Natural {
             (_, Natural(Small(y)), _) => self.add_mul_assign_limb_ref(z, *y),
             (_, _, Natural(Small(z))) => self.add_mul_assign_limb(y, *z),
             (Natural(Large(ref mut xs)), Natural(Large(ref ys)), Natural(Large(ref zs))) => {
-                limbs_add_mul_in_place_left(xs, ys, zs)
+                limbs_add_mul_in_place_left(xs, ys, zs);
             }
         }
     }
@@ -699,7 +699,7 @@ impl<'a> AddMulAssign<&'a Natural, Natural> for Natural {
             (_, Natural(Small(y)), _) => self.add_mul_assign_limb(z, *y),
             (_, _, Natural(Small(z))) => self.add_mul_assign_limb_ref(y, *z),
             (Natural(Large(ref mut xs)), Natural(Large(ref ys)), Natural(Large(ref zs))) => {
-                limbs_add_mul_in_place_left(xs, ys, zs)
+                limbs_add_mul_in_place_left(xs, ys, zs);
             }
         }
     }
@@ -738,7 +738,7 @@ impl<'a, 'b> AddMulAssign<&'a Natural, &'b Natural> for Natural {
             (_, Natural(Small(y)), _) => self.add_mul_assign_limb_ref(z, *y),
             (_, _, Natural(Small(z))) => self.add_mul_assign_limb_ref(y, *z),
             (Natural(Large(ref mut xs)), Natural(Large(ref ys)), Natural(Large(ref zs))) => {
-                limbs_add_mul_in_place_left(xs, ys, zs)
+                limbs_add_mul_in_place_left(xs, ys, zs);
             }
         }
     }

--- a/malachite-nz/src/natural/arithmetic/mul/mod.rs
+++ b/malachite-nz/src/natural/arithmetic/mul/mod.rs
@@ -481,19 +481,18 @@ pub_crate_test! {limbs_mul_greater_to_out_basecase(out: &mut [Limb], xs: &[Limb]
     // We first multiply by the low order limb. This result can be stored, not added, to out.
     out[xs_len] = limbs_mul_limb_to_out(out, xs, ys[0]);
     // Now accumulate the product of xs and the next higher limb from ys.
-    let mut bottom = 1;
-    let mut top = bottom + xs_len + 1;
+    let window_size = xs_len + 1;
+    let mut i = 1;
+    let max = ys_len - 1;
 
-    while top < out.len() {
-        let (out_last, out_init) = out[bottom..=top].split_last_mut().unwrap();
-        *out_last = limbs_slice_add_mul_two_limbs_matching_length_in_place_left(out_init, xs, [ys[bottom], ys[bottom + 1]]);
-        bottom += 2;
-        top += 2;
+    while i < max {
+        let (out_last, out_init) = out[i..=i + window_size].split_last_mut().unwrap();
+        *out_last = limbs_slice_add_mul_two_limbs_matching_length_in_place_left(out_init, xs, [ys[i], ys[i + 1]]);
+        i += 2;
     }
 
-    if top <= out.len() {
-        let i = ys_len - 1;
-        let (out_last, out_init) = out[bottom..top].split_last_mut().unwrap();
+    if i <= max {
+        let (out_last, out_init) = out[i..i + window_size].split_last_mut().unwrap();
         *out_last = limbs_slice_add_mul_limb_same_length_in_place_left(out_init, xs, ys[i]);
     }
 }}

--- a/malachite-nz/src/natural/arithmetic/mul/mod.rs
+++ b/malachite-nz/src/natural/arithmetic/mul/mod.rs
@@ -16,7 +16,7 @@
 use crate::natural::arithmetic::add::limbs_slice_add_greater_in_place_left;
 use crate::natural::arithmetic::add_mul::{
     limbs_slice_add_mul_limb_same_length_in_place_left,
-    limbs_slice_add_mul_two_limbs_same_length_in_place_left,
+    limbs_slice_add_mul_two_limbs_matching_length_in_place_left,
 };
 use crate::natural::arithmetic::mul::fft::{
     limbs_mul_greater_to_out_fft, limbs_mul_greater_to_out_fft_scratch_len,
@@ -486,7 +486,7 @@ pub_crate_test! {limbs_mul_greater_to_out_basecase(out: &mut [Limb], xs: &[Limb]
 
     while top < out.len() {
         let (out_last, out_init) = out[bottom..=top].split_last_mut().unwrap();
-        *out_last = limbs_slice_add_mul_two_limbs_same_length_in_place_left(out_init, xs, [ys[bottom], ys[bottom + 1]]);
+        *out_last = limbs_slice_add_mul_two_limbs_matching_length_in_place_left(out_init, xs, [ys[bottom], ys[bottom + 1]]);
         bottom += 2;
         top += 2;
     }

--- a/malachite-nz/src/natural/arithmetic/mul/mod.rs
+++ b/malachite-nz/src/natural/arithmetic/mul/mod.rs
@@ -14,7 +14,10 @@
 // 3 of the License, or (at your option) any later version. See <https://www.gnu.org/licenses/>.
 
 use crate::natural::arithmetic::add::limbs_slice_add_greater_in_place_left;
-use crate::natural::arithmetic::add_mul::limbs_slice_add_mul_limb_same_length_in_place_left;
+use crate::natural::arithmetic::add_mul::{
+    limbs_slice_add_mul_limb_same_length_in_place_left,
+    limbs_slice_add_mul_two_limbs_same_length_in_place_left,
+};
 use crate::natural::arithmetic::mul::fft::{
     limbs_mul_greater_to_out_fft, limbs_mul_greater_to_out_fft_scratch_len,
 };
@@ -478,8 +481,17 @@ pub_crate_test! {limbs_mul_greater_to_out_basecase(out: &mut [Limb], xs: &[Limb]
     out[xs_len] = limbs_mul_limb_to_out(out, xs, ys[0]);
     // Now accumulate the product of xs and the next higher limb from ys.
     let window_size = xs_len + 1;
-    for i in 1..ys_len {
-        let (out_last, out_init) = out[i..i + window_size].split_last_mut().unwrap();
+    let mut i = 1;
+
+    while i < ys_len - 1 {
+        let (out_last, out_init) = unsafe { out.get_unchecked_mut(i..i + window_size + 1).split_last_mut().unwrap_unchecked() };
+        *out_last = limbs_slice_add_mul_two_limbs_same_length_in_place_left(out_init, xs, [ys[i], ys[i + 1]]);
+        i += 2;
+    }
+
+    if ys_len & 1 == 0 {
+        let i = ys_len - 1;
+        let (out_last, out_init) = unsafe { out.get_unchecked_mut(i..i + window_size).split_last_mut().unwrap_unchecked() };
         *out_last = limbs_slice_add_mul_limb_same_length_in_place_left(out_init, xs, ys[i]);
     }
 }}


### PR DESCRIPTION
This is another potential optimization I found while profiling an application focused on large GCDs. For me, it yields a performance improvement of approximately 6% for GCDs on the order of ~1 MiB operands. Interestingly, multiplication at a similar size profits somewhat less (only 3-4% IIRC). Numbers are on `stable-x86_64-pc-windows-msvc` compiled for target-CPU `x86-64-v3`. This time I benched again using WSL with `stable-x86_64-unknown-linux-gnu` and got reasonably similar results - still running on the same Windows host machine, though.

The optimization is done in two parts: First, I made `limbs_slice_add_mul_limb_same_length_in_place_left` more similar to the corresponding GMP implementation, which yielded a performance improvement of approx. 2.6%. The rest was obtained by processing two limbs from the `ys` slice in `limbs_mul_greater_to_out_basecase` at the same time. GMP has platform-specific assembly for this, but even just implementing it regularly seems to improve performance (perhaps better locality?).