### PR TITLE
Set MSRV to 1.74.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,10 +418,10 @@ name = "malachite"
 version = "0.4.14"
 dependencies = [
  "embed-doc-image",
- "malachite-base",
- "malachite-float",
- "malachite-nz",
- "malachite-q",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-float 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-nz 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-q 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -435,7 +435,7 @@ dependencies = [
  "hashbrown",
  "itertools 0.11.0",
  "libm",
- "malachite-base",
+ "malachite-base 0.4.14",
  "maplit",
  "rand",
  "rand_chacha",
@@ -446,12 +446,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite-base"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c817c713ff9f16e06cfdc23baa3fecf1b71eaaac714816a98a560f4e350aa6"
+dependencies = [
+ "clap",
+ "getrandom",
+ "gnuplot",
+ "hashbrown",
+ "itertools 0.11.0",
+ "libm",
+ "rand",
+ "rand_chacha",
+ "ryu",
+ "sha3",
+ "time",
+]
+
+[[package]]
 name = "malachite-criterion-bench"
 version = "0.4.14"
 dependencies = [
  "criterion",
- "malachite-base",
- "malachite-nz",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-nz 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "num",
  "rug",
 ]
@@ -461,14 +480,27 @@ name = "malachite-float"
 version = "0.4.14"
 dependencies = [
  "itertools 0.11.0",
- "malachite-base",
- "malachite-float",
- "malachite-nz",
- "malachite-q",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-float 0.4.14",
+ "malachite-nz 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-q 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "num",
  "rug",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "malachite-float"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4fc2c9c0893bae56d0690c01df3117e116edb08fe18a06b4c5337e60bf526d3"
+dependencies = [
+ "itertools 0.11.0",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-nz 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-q 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
@@ -479,8 +511,26 @@ dependencies = [
  "indoc",
  "itertools 0.11.0",
  "libm",
- "malachite-base",
- "malachite-nz",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-nz 0.4.14",
+ "num",
+ "pyo3",
+ "pyo3-build-config",
+ "rug",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603729facf62429736ac17a9fc9fe1bf7e0eb8bde3da3b18cc2b6153150464d5"
+dependencies = [
+ "indoc",
+ "itertools 0.11.0",
+ "libm",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "num",
  "pyo3",
  "pyo3-build-config",
@@ -494,9 +544,24 @@ name = "malachite-q"
 version = "0.4.14"
 dependencies = [
  "itertools 0.11.0",
- "malachite-base",
- "malachite-nz",
- "malachite-q",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-nz 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-q 0.4.14",
+ "num",
+ "rug",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73844ccbf0e9baaf34d4a6d187f0d6a925ce8e74ef37a67d238e7d65529b38c"
+dependencies = [
+ "itertools 0.11.0",
+ "malachite-base 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malachite-nz 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "num",
  "rug",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 members = ['malachite', 'malachite-base', 'malachite-float', 'malachite-nz', 'malachite-q', 'malachite-criterion-bench']
 resolver = "2"
 
+[workspace.package]
+edition = "2021"
+rust-version = "1.74.0"
+
 [workspace.dependencies]
 malachite-base = { version = "0.4.14", path = 'malachite-base' }
 malachite-nz = { version = "0.4.14", path = 'malachite-nz', default_features = false }

--- a/malachite-base/Cargo.toml
+++ b/malachite-base/Cargo.toml
@@ -2,8 +2,8 @@
 name = "malachite-base"
 version = "0.4.14"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
-rust-version = "1.61.0"
-edition = "2021"
+rust-version.workspace = true
+edition.workspace = true
 description = "A collection of utilities, including new arithmetic traits and iterators that generate all values of a type"
 readme = "README.md"
 homepage = "https://malachite.rs/"

--- a/malachite-criterion-bench/Cargo.toml
+++ b/malachite-criterion-bench/Cargo.toml
@@ -3,7 +3,8 @@ name = "malachite-criterion-bench"
 version = "0.4.14"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
 autobenches = false
-edition = "2021"
+rust-version.workspace = true
+edition.workspace = true
 
 [dependencies]
 malachite-base = { version = "0.4.14" }

--- a/malachite-float/Cargo.toml
+++ b/malachite-float/Cargo.toml
@@ -2,8 +2,8 @@
 name = "malachite-float"
 version = "0.4.14"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
-rust-version = "1.61.0"
-edition = "2021"
+rust-version.workspace = true
+edition.workspace = true
 description = "The arbitrary-precision floating-point type Float, with efficient algorithms partially derived from MPFR"
 readme = "README.md"
 homepage = "https://malachite.rs/"

--- a/malachite-nz/Cargo.toml
+++ b/malachite-nz/Cargo.toml
@@ -2,8 +2,8 @@
 name = "malachite-nz"
 version = "0.4.14"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
-rust-version = "1.61.0"
-edition = "2021"
+rust-version.workspace = true
+edition.workspace = true
 description = "The bignum types Natural and Integer, with efficient algorithms partially derived from GMP and FLINT"
 readme = "README.md"
 homepage = "https://malachite.rs/"

--- a/malachite-q/Cargo.toml
+++ b/malachite-q/Cargo.toml
@@ -2,8 +2,8 @@
 name = "malachite-q"
 version = "0.4.14"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
-rust-version = "1.61.0"
-edition = "2021"
+rust-version.workspace = true
+edition.workspace = true
 description = "The arbitrary-precision type Rational, with efficient algorithms partially derived from GMP and FLINT"
 readme = "README.md"
 homepage = "https://malachite.rs/"

--- a/malachite/Cargo.toml
+++ b/malachite/Cargo.toml
@@ -2,8 +2,8 @@
 name = "malachite"
 version = "0.4.14"
 authors = ["Mikhail Hogrefe <mikhailhogrefe@gmail.com>"]
-rust-version = "1.61.0"
-edition = "2021"
+rust-version.workspace = true
+edition.workspace = true
 description = "Arbitrary-precision arithmetic, with efficient algorithms partially derived from GMP and FLINT"
 readme = "../README.md"
 homepage = "https://malachite.rs/"


### PR DESCRIPTION
Compilation fails on 1.73

```
warning: unknown lint: `private_interfaces`
   --> malachite-q/src/exhaustive/mod.rs:810:1
    |
810 | #[allow(private_interfaces)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the `private_interfaces` lint is unstable
    = note: see issue #48054 <https://github.com/rust-lang/rust/issues/48054> for more information
    = note: `#[warn(unknown_lints)]` on by default

warning: unknown lint: `private_interfaces`
   --> malachite-q/src/exhaustive/mod.rs:930:1
    |
930 | #[allow(private_interfaces)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the `private_interfaces` lint is unstable
    = note: see issue #48054 <https://github.com/rust-lang/rust/issues/48054> for more information

error[E0446]: private type `ExhaustiveRationalsWithDenominatorRangeGenerator` in public interface
   --> /home/jayvdb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/malachite-q-0.4.14/src/exhaustive/mod.rs:815:9
    |
770 |   struct ExhaustiveRationalsWithDenominatorRangeGenerator {
    |   ------------------------------------------------------- `ExhaustiveRationalsWithDenominatorRangeGenerator` declared as private
...
815 | /         ExhaustiveDependentPairs<
816 | |             Natural,
817 | |             Rational,
818 | |             RulerSequence<usize>,
...   |
821 | |             RationalsWithDenominator<ExhaustiveIntegerRange>,
822 | |         >,
    | |_________^ can't leak private type

...
```