### PR TITLE
Replace derive_more with manual macros in malachite-bigint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -428,7 +428,7 @@ dependencies = [
  "getrandom",
  "gnuplot",
  "hashbrown",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "libm",
  "malachite-base",
  "maplit",
@@ -467,7 +467,7 @@ dependencies = [
 name = "malachite-float"
 version = "0.5.1"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-float",
  "malachite-nz",
@@ -484,7 +484,7 @@ version = "0.5.1"
 dependencies = [
  "embed-doc-image",
  "indoc",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "libm",
  "malachite-base",
  "malachite-nz",
@@ -500,7 +500,7 @@ dependencies = [
 name = "malachite-q"
 version = "0.5.1"
 dependencies = [
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
  "malachite-q",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,27 +220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
- "unicode-xid",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +444,6 @@ dependencies = [
 name = "malachite-bigint"
 version = "0.5.1"
 dependencies = [
- "derive_more",
  "malachite-base",
  "malachite-nz",
  "num-bigint",
@@ -1076,12 +1054,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"

--- a/malachite-base/Cargo.toml
+++ b/malachite-base/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/bin.rs"
 test = false
 
 [dependencies]
-itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
 ryu = { version = "1.0.15", default-features = false }
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
 libm = { version = "0.2.8", default-features = false }

--- a/malachite-base/src/iterators/mod.rs
+++ b/malachite-base/src/iterators/mod.rs
@@ -248,7 +248,7 @@ pub fn matching_intervals_in_iterator<I: Iterator, F: Fn(&I::Item) -> bool>(
 where
     I::Item: Clone,
 {
-    xs.group_by(predicate)
+    xs.chunk_by(predicate)
         .into_iter()
         .filter_map(|(b, mut group)| if b { first_and_last(&mut group) } else { None })
         .collect()

--- a/malachite-bigint/Cargo.toml
+++ b/malachite-bigint/Cargo.toml
@@ -14,6 +14,5 @@ malachite-nz = { version = "0.5.1", path = "../malachite-nz" }
 
 num-traits = { version = "0.2.19", default-features = false, features = ["i128"] }
 num-integer = { version = "0.1.46", default-features = false, features = ["i128"] }
-derive_more = { version = "1.0.0", features = ["display", "from", "into"] }
 paste = "1.0.15"
 num-bigint = { version = "0.4", default-features = false, optional = true }

--- a/malachite-bigint/src/bigint.rs
+++ b/malachite-bigint/src/bigint.rs
@@ -1,4 +1,3 @@
-use derive_more::{Binary, Display, From, Into, LowerHex, Octal, UpperHex};
 use malachite_base::{
     num::{
         arithmetic::traits::{
@@ -63,28 +62,13 @@ impl Neg for Sign {
 }
 
 #[repr(transparent)]
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    Display,
-    Binary,
-    Octal,
-    LowerHex,
-    UpperHex,
-    From,
-    Into,
-)]
-#[display("{}", self.0)]
-#[into(owned, ref, ref_mut)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BigInt(Integer);
 
 apply_to_primitives!(forward_from{BigInt, _});
 apply_to_primitives!(forward_try_into{BigInt, _});
+
+impl_from!(BigInt, Integer);
 
 forward_unary_op!(BigInt, Not, not);
 forward_unary_op!(BigInt, Neg, neg);
@@ -138,11 +122,7 @@ apply_to_unsigneds!(forward_pow_primitive{BigInt, _});
 impl_product_iter_type!(BigInt);
 impl_sum_iter_type!(BigInt);
 
-impl std::fmt::Debug for BigInt {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
+forward_fmt!(BigInt, Debug, Display, Binary, Octal, LowerHex, UpperHex);
 
 impl CheckedAdd for BigInt {
     #[inline]

--- a/malachite-bigint/src/biguint.rs
+++ b/malachite-bigint/src/biguint.rs
@@ -1,4 +1,3 @@
-use derive_more::{Binary, Display, From, Into, LowerHex, Octal, UpperHex};
 use malachite_base::{
     num::{
         arithmetic::traits::{
@@ -18,7 +17,6 @@ use num_traits::{
 use paste::paste;
 use std::{
     cmp::Ordering::{Equal, Greater, Less},
-    fmt::Debug,
     iter::{Product, Sum},
     ops::{
         Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div,
@@ -38,29 +36,14 @@ impl_primitive_convert!(BigUint, f32);
 impl_primitive_convert!(BigUint, f64);
 
 #[repr(transparent)]
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    Display,
-    Binary,
-    Octal,
-    LowerHex,
-    UpperHex,
-    From,
-    Into,
-)]
-#[display("{}", self.0)]
-#[into(owned, ref, ref_mut)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BigUint(pub(crate) Natural);
 
 apply_to_unsigneds!(forward_from{BigUint, _});
 apply_to_signeds!(forward_try_from{BigUint, _});
 apply_to_primitives!(forward_try_into{BigUint, _});
+
+impl_from!(BigUint, Natural);
 
 forward_binary_self!(BigUint, Add, add);
 forward_binary_self!(BigUint, Sub, sub);
@@ -111,11 +94,7 @@ apply_to_unsigneds!(forward_pow_primitive{BigUint, _});
 impl_product_iter_type!(BigUint);
 impl_sum_iter_type!(BigUint);
 
-impl std::fmt::Debug for BigUint {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
+forward_fmt!(BigUint, Debug, Display, Binary, Octal, LowerHex, UpperHex);
 
 impl CheckedAdd for BigUint {
     #[inline]

--- a/malachite-bigint/src/macros.rs
+++ b/malachite-bigint/src/macros.rs
@@ -447,3 +447,41 @@ macro_rules! impl_to_primitive_fn_float {
         }
     };
 }
+
+macro_rules! forward_fmt {
+    ($t:ty, $($trait:ident),*) => {
+        $(impl core::fmt::$trait for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                core::fmt::$trait::fmt(&self.0, f)
+            }
+        })*
+    }
+}
+
+macro_rules! impl_from {
+    ($wrapper:ty, $inner: ty) => {
+        impl From<$inner> for $wrapper {
+            fn from(value: $inner) -> Self {
+                Self(value)
+            }
+        }
+        impl From<$wrapper> for $inner {
+            #[inline]
+            fn from(value: $wrapper) -> Self {
+                value.0
+            }
+        }
+        impl<'a> From<&'a $wrapper> for &'a $inner {
+            #[inline]
+            fn from(value: &'a $wrapper) -> Self {
+                &value.0
+            }
+        }
+        impl<'a> From<&'a mut $wrapper> for &'a mut $inner {
+            #[inline]
+            fn from(value: &'a mut $wrapper) -> Self {
+                &mut value.0
+            }
+        }
+    };
+}

--- a/malachite-float/Cargo.toml
+++ b/malachite-float/Cargo.toml
@@ -21,7 +21,7 @@ name = "malachite_float_main"
 path = "src/bin.rs"
 
 [dependencies]
-itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
 malachite-base = { version = "0.5.1", default-features = false, path = "../malachite-base" }
 malachite-nz = { version = "0.5.1", default-features = false, features = ["float_helpers"], path = "../malachite-nz" }
 malachite-q = { version = "0.5.1", default-features = false, path = "../malachite-q" }

--- a/malachite-nz/Cargo.toml
+++ b/malachite-nz/Cargo.toml
@@ -21,7 +21,7 @@ name = "malachite_nz_main"
 path = "src/bin.rs"
 
 [dependencies]
-itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
 libm = { version = "0.2.8", default-features = false }
 malachite-base = { version = "0.5.1", default-features = false, path = "../malachite-base" }
 serde = { version = "1.0.188", optional = true, default-features = false, features = ["alloc", "derive"] }

--- a/malachite-nz/tests/integer/conversion/to_twos_complement_limbs.rs
+++ b/malachite-nz/tests/integer/conversion/to_twos_complement_limbs.rs
@@ -15,8 +15,8 @@ use malachite_base::test_util::generators::common::GenConfig;
 use malachite_base::test_util::generators::{
     signed_gen, unsigned_gen_var_5, unsigned_vec_gen, unsigned_vec_gen_var_2,
 };
-use malachite_nz::integer::Integer;
 use malachite_nz::integer::conversion::to_twos_complement_limbs::*;
+use malachite_nz::integer::Integer;
 use malachite_nz::natural::Natural;
 use malachite_nz::platform::{Limb, SignedLimb};
 use malachite_nz::test_util::generators::{
@@ -380,19 +380,19 @@ fn twos_complement_limbs_properties() {
     integer_unsigned_pair_gen_var_2().test_properties(|(n, u)| {
         if u < n.unsigned_abs_ref().limb_count() {
             assert_eq!(
-                n.twos_complement_limbs().get(u),
+                (&n.twos_complement_limbs()).get(u),
                 n.to_twos_complement_limbs_asc()[usize::exact_from(u)]
             );
         } else {
             assert_eq!(
-                n.twos_complement_limbs().get(u),
+                (&n.twos_complement_limbs()).get(u),
                 if n >= 0 { 0 } else { Limb::MAX }
             );
         }
     });
 
     unsigned_gen_var_5().test_properties(|u| {
-        assert_eq!(Integer::ZERO.twos_complement_limbs().get(u), 0);
+        assert_eq!((&Integer::ZERO.twos_complement_limbs()).get(u), 0);
     });
 }
 

--- a/malachite-q/Cargo.toml
+++ b/malachite-q/Cargo.toml
@@ -21,7 +21,7 @@ name = "malachite_q_main"
 path = "src/bin.rs"
 
 [dependencies]
-itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
 malachite-base = { version = "0.5.1", default-features = false, path = "../malachite-base" }
 malachite-nz = { version = "0.5.1", default-features = false, path = "../malachite-nz" }
 serde = { version = "1.0.188", optional = true, default-features = false, features = ["alloc", "derive"] }


### PR DESCRIPTION
Now syn isn't a transitive dependency, which can speed up build times. And it turns out this is less code overall :)