### PR TITLE
Add IsSquare and IsPerfectPower based on flint implementations

### DIFF
--- a/malachite-base/src/num/factorization/factor.rs
+++ b/malachite-base/src/num/factorization/factor.rs
@@ -23,7 +23,7 @@ use crate::num::basic::integers::{PrimitiveInt, USIZE_IS_U32};
 use crate::num::basic::unsigneds::PrimitiveUnsigned;
 use crate::num::conversion::traits::{ExactFrom, WrappingFrom};
 use crate::num::factorization::primes::SMALL_PRIMES;
-use crate::num::factorization::traits::{Factor, IsPrime, Primes};
+use crate::num::factorization::traits::{Factor, IsPrime, IsSquare, Primes};
 use crate::num::logic::traits::{LeadingZeros, LowMask, SignificantBits};
 use core::mem::swap;
 
@@ -323,38 +323,6 @@ fn factor_power23_u64(n: u64) -> (u64, u8) {
     (0, 0)
 }
 
-const IS_SQUARE_MOD64: [bool; 64] = [
-    true, true, false, false, true, false, false, false, false, true, false, false, false, false,
-    false, false, true, true, false, false, false, false, false, false, false, true, false, false,
-    false, false, false, false, false, true, false, false, true, false, false, false, false, true,
-    false, false, false, false, false, false, false, true, false, false, false, false, false,
-    false, false, true, false, false, false, false, false, false,
-];
-
-const IS_SQUARE_MOD65: [bool; 65] = [
-    true, true, false, false, true, false, false, false, false, true, true, false, false, false,
-    true, false, true, false, false, false, false, false, false, false, false, true, true, false,
-    false, true, true, false, false, false, false, true, true, false, false, true, true, false,
-    false, false, false, false, false, false, false, true, false, true, false, false, false, true,
-    true, false, false, false, false, true, false, false, true,
-];
-
-const IS_SQUARE_MOD63: [bool; 63] = [
-    true, true, false, false, true, false, false, true, false, true, false, false, false, false,
-    true, false, true, false, true, false, false, false, true, false, false, true, false, false,
-    true, false, false, false, false, false, false, true, true, true, false, false, false, false,
-    false, true, false, false, true, false, false, true, false, false, false, false, false, false,
-    true, false, true, false, false, false, false,
-];
-
-// This is n_is_square when FLINT64 is false, from ulong_extras/is_square.c, FLINT 3.1.2.
-fn is_square_u64(x: u64) -> bool {
-    IS_SQUARE_MOD64[(x % 64) as usize]
-        && IS_SQUARE_MOD63[(x % 63) as usize]
-        && IS_SQUARE_MOD65[(x % 65) as usize]
-        && x.floor_sqrt().square() == x
-}
-
 const FLINT_ONE_LINE_MULTIPLIER: u32 = 480;
 
 // This is n_factor_one_line when FLINT64 is true, from ulong_extras/factor_one_line.c, FLINT 3.1.2.
@@ -370,7 +338,7 @@ fn factor_one_line_u64(mut n: u64, iters: usize) -> u64 {
         let mut sqrti = inn.floor_sqrt() + 1;
         let square = sqrti.square();
         let mmod = square - inn;
-        if is_square_u64(mmod) {
+        if mmod.is_square() {
             sqrti -= mmod.floor_sqrt();
             let factor = orig_n.gcd(sqrti);
             if factor != 1 {
@@ -677,7 +645,7 @@ fn ll_factor_squfof_u64(n_hi: u64, n_lo: u64, max_iters: usize) -> u64 {
         qlast = q;
         q = t;
         p = pnext;
-        if i.odd() || !is_square_u64(q) {
+        if i.odd() || !q.is_square() {
             continue;
         }
         r = q.floor_sqrt();

--- a/malachite-base/src/num/factorization/is_perfect_power.rs
+++ b/malachite-base/src/num/factorization/is_perfect_power.rs
@@ -1,0 +1,364 @@
+// Copyright © 2025 William Youmans
+//
+// Uses code adopted from the FLINT Library.
+//
+//      Copyright © 2009 William Hart
+//
+// This file is part of Malachite.
+//
+// Malachite is free software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License (LGPL as published by the Free Software Foundation; either version
+// 3 of the License, or (at your option any later version. See <https://www.gnu.org/licenses/>.
+
+use crate::num::arithmetic::traits::{RootRem, SqrtRem};
+use crate::num::basic::integers::USIZE_IS_U32;
+use crate::num::conversion::traits::ExactFrom;
+use crate::num::factorization::traits::IsPerfectPower;
+
+// The following arrays are bitmasks indicating whether an integer is a 2, 3, or 5th power residue.
+// For example, modulo 31 we have:
+//     squares:    {0, 1, 2, 4, 5, 7, 8, 9, 10, 14, 16, 18, 19, 20, 25, 28}
+//     cubes:      {0, 1, 2, 4, 8, 15, 16, 23, 27, 29, 30}
+//     5th powers: {0, 1, 5, 6, 25, 26, 30}
+// Since 2 is a square, cube, but not a 5th power mod 31, we encode it as 011 = 3. Then MOD31[2] = 3.
+
+const MOD63: [u8; 63] = [
+    7, 7, 4, 0, 5, 4, 0, 5, 6, 5, 4, 4, 0, 4, 4, 0, 5, 4, 5, 4, 4, 0, 5, 4, 0, 5, 4, 6, 7, 4, 0, 4,
+    4, 0, 4, 6, 7, 5, 4, 0, 4, 4, 0, 5, 4, 4, 5, 4, 0, 5, 4, 0, 4, 4, 4, 6, 4, 0, 5, 4, 0, 4, 6,
+];
+
+const MOD61: [u8; 61] = [
+    7, 7, 0, 3, 1, 1, 0, 0, 2, 3, 0, 6, 1, 5, 5, 1, 1, 0, 0, 1, 3, 4, 1, 2, 2, 1, 0, 3, 2, 4, 0, 0,
+    4, 2, 3, 0, 1, 2, 2, 1, 4, 3, 1, 0, 0, 1, 1, 5, 5, 1, 6, 0, 3, 2, 0, 0, 1, 1, 3, 0, 7,
+];
+
+const MOD44: [u8; 44] = [
+    7, 7, 0, 2, 3, 3, 0, 2, 2, 3, 0, 6, 7, 2, 0, 2, 3, 2, 0, 2, 3, 6, 0, 6, 2, 3, 0, 2, 2, 2, 0, 2,
+    6, 7, 0, 2, 3, 3, 0, 2, 2, 2, 0, 6,
+];
+
+const MOD31: [u8; 31] =
+    [7, 7, 3, 0, 3, 5, 4, 1, 3, 1, 1, 0, 0, 0, 1, 2, 3, 0, 1, 1, 1, 0, 0, 2, 0, 5, 4, 2, 1, 2, 6];
+
+const MOD72: [u8; 72] = [
+    7, 7, 0, 0, 0, 7, 0, 7, 7, 7, 0, 7, 0, 7, 0, 0, 7, 7, 0, 7, 0, 0, 0, 7, 0, 7, 0, 7, 0, 7, 0, 7,
+    7, 0, 0, 7, 0, 7, 0, 0, 7, 7, 0, 7, 0, 7, 0, 7, 0, 7, 0, 0, 0, 7, 0, 7, 7, 0, 0, 7, 0, 7, 0, 7,
+    7, 7, 0, 7, 0, 0, 0, 7,
+];
+
+const MOD49: [u8; 49] = [
+    1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+];
+
+const MOD67: [u8; 67] = [
+    2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0,
+    0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 2,
+];
+
+const MOD79: [u8; 79] = [
+    4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
+];
+
+// This is n_is_perfect_power when FLINT64 is false, from ulong_extras/is_power.c, FLINT 3.1.2.
+fn is_perfect_power_u32(n: u32) -> Option<(u32, u32)> {
+    if n == 0 || n == 1 {
+        return None;
+    }
+
+    // Check for powers 2, 3, 5
+    let mut t = MOD31[(n % 31) as usize];
+    t &= MOD44[(n % 44) as usize];
+    t &= MOD61[(n % 61) as usize];
+    t &= MOD63[(n % 63) as usize];
+
+    // Check for perfect square
+    if t & 1 != 0 {
+        let (rt, rem) = n.sqrt_rem();
+        if rem == 0 {
+            return Some((rt, 2));
+        }
+    }
+
+    // Check for perfect cube
+    if t & 2 != 0 {
+        let (rt, rem) = n.root_rem(3);
+        if rem == 0 {
+            return Some((rt, 3));
+        }
+    }
+
+    // Check for perfect fifth power
+    if t & 4 != 0 {
+        let (rt, rem) = n.root_rem(5);
+        if rem == 0 {
+            return Some((rt, 5));
+        }
+    }
+
+    // Check for powers 7, 11, 13
+    t = MOD49[(n % 49) as usize];
+    t |= MOD67[(n % 67) as usize];
+    t |= MOD79[(n % 79) as usize];
+    t &= MOD72[(n % 72) as usize];
+
+    // Check for perfect 7th power
+    if t & 1 != 0 {
+        let (rt, rem) = n.root_rem(7);
+        if rem == 0 {
+            return Some((rt, 7));
+        }
+    }
+
+    // Check for perfect 11th power
+    if t & 2 != 0 {
+        let (rt, rem) = n.root_rem(11);
+        if rem == 0 {
+            return Some((rt, 11));
+        }
+    }
+
+    // Check for perfect 13th power
+    if t & 13 != 0 {
+        let (rt, rem) = n.root_rem(13);
+        if rem == 0 {
+            return Some((rt, 13));
+        }
+    }
+
+    // Handle powers of 2
+    let count = n.trailing_zeros();
+    let mut n = n >> count;
+
+    if n == 1 {
+        if count == 1 {
+            return None; // Just 2^1 = 2, not a perfect power
+        }
+        return Some((2, count));
+    }
+
+    // Check other powers (exp >= 17, root <= 13 and odd)
+    let mut exp = 0;
+    while (n % 3) == 0 {
+        n /= 3;
+        exp += 1;
+    }
+    if exp > 0 {
+        if n == 1 && exp > 1 {
+            if count == 0 {
+                return Some((3, exp));
+            } else if count == exp {
+                return Some((6, exp));
+            } else if count == 2 * exp {
+                return Some((12, exp));
+            }
+        }
+        return None;
+    }
+    None
+}
+
+// This is n_is_perfect_power when FLINT64 is true, from ulong_extras/is_power.c, FLINT 3.1.2.
+fn is_perfect_power_u64(n: u64) -> Option<(u64, u32)> {
+    if n == 0 || n == 1 {
+        return None;
+    }
+
+    // Check for powers 2, 3, 5
+    let mut t = MOD31[(n % 31) as usize];
+    t &= MOD44[(n % 44) as usize];
+    t &= MOD61[(n % 61) as usize];
+    t &= MOD63[(n % 63) as usize];
+
+    // Check for perfect square
+    if t & 1 != 0 {
+        let (rt, rem) = n.sqrt_rem();
+        if rem == 0 {
+            return Some((rt, 2));
+        }
+    }
+
+    // Check for perfect cube
+    if t & 2 != 0 {
+        let (rt, rem) = n.root_rem(3);
+        if rem == 0 {
+            return Some((rt, 3));
+        }
+    }
+
+    // Check for perfect fifth power
+    if t & 4 != 0 {
+        let (rt, rem) = n.root_rem(5);
+        if rem == 0 {
+            return Some((rt, 5));
+        }
+    }
+
+    // Check for powers 7, 11, 13
+    t = MOD49[(n % 49) as usize];
+    t |= MOD67[(n % 67) as usize];
+    t |= MOD79[(n % 79) as usize];
+    t &= MOD72[(n % 72) as usize];
+
+    // Check for perfect 7th power
+    if t & 1 != 0 {
+        let (rt, rem) = n.root_rem(7);
+        if rem == 0 {
+            return Some((rt, 7));
+        }
+    }
+
+    // Check for perfect 11th power
+    if t & 2 != 0 {
+        let (rt, rem) = n.root_rem(11);
+        if rem == 0 {
+            return Some((rt, 11));
+        }
+    }
+
+    // Check for perfect 13th power
+    if t & 13 != 0 {
+        let (rt, rem) = n.root_rem(13);
+        if rem == 0 {
+            return Some((rt, 13));
+        }
+    }
+
+    // Handle powers of 2
+    let count = n.trailing_zeros();
+    let mut n = n >> count;
+
+    if n == 1 {
+        if count == 1 {
+            return None; // Just 2^1 = 2, not a perfect power
+        }
+        return Some((2, count));
+    }
+
+    // Check other powers (exp >= 17, root <= 13 and odd)
+    let mut exp: u32 = 0;
+    while n % 3 == 0 {
+        n /= 3;
+        exp += 1;
+    }
+    if exp > 0 {
+        if n == 1 && exp > 1 {
+            if count == 0 {
+                return Some((3, exp));
+            } else if count == exp {
+                return Some((6, exp));
+            } else if count == 2 * exp {
+                return Some((12, exp));
+            }
+        }
+        return None;
+    }
+
+    // Check powers of 5
+    exp = 0;
+    while n % 5 == 0 {
+        n /= 5;
+        exp += 1;
+    }
+    if exp > 0 {
+        if n == 1 && exp > 1 {
+            if count == 0 {
+                return Some((5, exp));
+            } else if count == exp {
+                return Some((10, exp));
+            }
+        }
+        return None;
+    }
+
+    if count > 0 {
+        return None;
+    }
+
+    // Check powers of 7
+    exp = 0;
+    while n % 7 == 0 {
+        n /= 7;
+        exp += 1;
+    }
+    if exp > 0 {
+        if n == 1 && exp > 1 {
+            return Some((7, exp));
+        }
+        return None;
+    }
+
+    // Check powers of 11
+    exp = 0;
+    while n % 11 == 0 {
+        n /= 11;
+        exp += 1;
+    }
+    if exp > 0 {
+        if n == 1 && exp > 1 {
+            return Some((11, exp));
+        }
+        return None;
+    }
+
+    // Check powers of 13
+    exp = 0;
+    while n % 13 == 0 {
+        n /= 13;
+        exp += 1;
+    }
+    if exp > 0 {
+        if n == 1 && exp > 1 {
+            return Some((13, exp));
+        }
+        return None;
+    }
+
+    None
+}
+
+impl IsPerfectPower for u64 {
+    type Output = Option<(u64, u32)>;
+    #[inline]
+    fn is_perfect_power(&self) -> Self::Output {
+        is_perfect_power_u64(*self)
+    }
+}
+
+impl IsPerfectPower for usize {
+    type Output = Option<(usize, u32)>;
+    fn is_perfect_power(&self) -> Self::Output {
+        if USIZE_IS_U32 {
+            match is_perfect_power_u32(u32::exact_from(*self)) {
+                Some((base, exp)) => Some((usize::exact_from(base), exp)),
+                _ => None,
+            }
+        } else {
+            match is_perfect_power_u64(u64::exact_from(*self)) {
+                Some((base, exp)) => Some((usize::exact_from(base), exp)),
+                _ => None,
+            }
+        }
+    }
+}
+
+macro_rules! impl_unsigned_32 {
+    ($t: ident) => {
+        impl IsPerfectPower for $t {
+            type Output = Option<($t, u32)>;
+            fn is_perfect_power(&self) -> Self::Output {
+                match is_perfect_power_u32(u32::from(*self)) {
+                    Some((base, exp)) => Some(($t::exact_from(base), exp)),
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+impl_unsigned_32!(u8);
+impl_unsigned_32!(u16);
+impl_unsigned_32!(u32);

--- a/malachite-base/src/num/factorization/is_square.rs
+++ b/malachite-base/src/num/factorization/is_square.rs
@@ -11,6 +11,7 @@
 // 3 of the License, or (at your option any later version. See <https://www.gnu.org/licenses/>.
 
 use crate::num::arithmetic::traits::{FloorSqrt, Square};
+use crate::num::conversion::traits::ExactFrom;
 use crate::num::factorization::traits::IsSquare;
 
 const IS_SQUARE_MOD64: [bool; 64] = [
@@ -50,7 +51,7 @@ macro_rules! impl_unsigned {
         impl IsSquare for $t {
             #[inline]
             fn is_square(&self) -> bool {
-                is_square_u64(*self as u64)
+                is_square_u64(u64::exact_from(*self))
             }
         }
     };

--- a/malachite-base/src/num/factorization/is_square.rs
+++ b/malachite-base/src/num/factorization/is_square.rs
@@ -1,0 +1,70 @@
+// Copyright © 2025 William Youmans
+//
+// Uses code adopted from the FLINT Library.
+//
+//      Copyright © 2009 William Hart
+//
+// This file is part of Malachite.
+//
+// Malachite is free software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License (LGPL as published by the Free Software Foundation; either version
+// 3 of the License, or (at your option any later version. See <https://www.gnu.org/licenses/>.
+
+use crate::num::arithmetic::traits::{FloorSqrt, Square};
+use crate::num::factorization::traits::IsSquare;
+
+const IS_SQUARE_MOD64: [bool; 64] = [
+    true, true, false, false, true, false, false, false, false, true, false, false, false, false,
+    false, false, true, true, false, false, false, false, false, false, false, true, false, false,
+    false, false, false, false, false, true, false, false, true, false, false, false, false, true,
+    false, false, false, false, false, false, false, true, false, false, false, false, false,
+    false, false, true, false, false, false, false, false, false,
+];
+
+const IS_SQUARE_MOD65: [bool; 65] = [
+    true, true, false, false, true, false, false, false, false, true, true, false, false, false,
+    true, false, true, false, false, false, false, false, false, false, false, true, true, false,
+    false, true, true, false, false, false, false, true, true, false, false, true, true, false,
+    false, false, false, false, false, false, false, true, false, true, false, false, false, true,
+    true, false, false, false, false, true, false, false, true,
+];
+
+const IS_SQUARE_MOD63: [bool; 63] = [
+    true, true, false, false, true, false, false, true, false, true, false, false, false, false,
+    true, false, true, false, true, false, false, false, true, false, false, true, false, false,
+    true, false, false, false, false, false, false, true, true, true, false, false, false, false,
+    false, true, false, false, true, false, false, true, false, false, false, false, false, false,
+    true, false, true, false, false, false, false,
+];
+
+// This is n_is_square when FLINT64 is false, from ulong_extras/is_square.c, FLINT 3.1.2.
+fn is_square_u64(x: u64) -> bool {
+    IS_SQUARE_MOD64[(x % 64) as usize]
+        && IS_SQUARE_MOD63[(x % 63) as usize]
+        && IS_SQUARE_MOD65[(x % 65) as usize]
+        && x.floor_sqrt().square() == x
+}
+
+macro_rules! impl_unsigned {
+    ($t: ident) => {
+        impl IsSquare for $t {
+            #[inline]
+            fn is_square(&self) -> bool {
+                is_square_u64(*self as u64)
+            }
+        }
+    };
+}
+apply_to_unsigneds!(impl_unsigned);
+
+macro_rules! impl_signed {
+    ($t: ident) => {
+        impl IsSquare for $t {
+            #[inline]
+            fn is_square(&self) -> bool {
+                false
+            }
+        }
+    };
+}
+apply_to_signeds!(impl_signed);

--- a/malachite-base/src/num/factorization/mod.rs
+++ b/malachite-base/src/num/factorization/mod.rs
@@ -8,6 +8,8 @@
 
 /// [`Factor`](traits::Factor), a trait for computing the prime factorization of a number.
 pub mod factor;
+/// [`IsPerfectPower`](traits::IsPerfectPower), a trait for testing if a number if a perfect power.
+pub mod is_perfect_power;
 /// [`IsPrime`](traits::IsPrime), a trait for testing a number for primality.
 pub mod is_prime;
 /// [`IsSquare`](traits::IsSquare), a trait for testing if a number if a perfect square.

--- a/malachite-base/src/num/factorization/mod.rs
+++ b/malachite-base/src/num/factorization/mod.rs
@@ -10,6 +10,8 @@
 pub mod factor;
 /// [`IsPrime`](traits::IsPrime), a trait for testing a number for primality.
 pub mod is_prime;
+/// [`IsSquare`](traits::IsSquare), a trait for testing if a number if a perfect square.
+pub mod is_square;
 /// An efficient prime sieve.
 pub mod prime_sieve;
 /// [`Primes`](traits::Primes), a trait for generating prime numbers.

--- a/malachite-base/src/num/factorization/traits.rs
+++ b/malachite-base/src/num/factorization/traits.rs
@@ -16,6 +16,12 @@ pub trait IsSquare {
     fn is_square(&self) -> bool;
 }
 
+/// A trait for testing whether a number is a perfect power.
+pub trait IsPerfectPower {
+    type Output;
+    fn is_perfect_power(&self) -> Self::Output;
+}
+
 /// A trait for finding the prime factorization of a number.
 pub trait Factor {
     type FACTORS;

--- a/malachite-base/src/num/factorization/traits.rs
+++ b/malachite-base/src/num/factorization/traits.rs
@@ -11,6 +11,11 @@ pub trait IsPrime {
     fn is_prime(&self) -> bool;
 }
 
+/// A trait for testing whether a number is a square.
+pub trait IsSquare {
+    fn is_square(&self) -> bool;
+}
+
 /// A trait for finding the prime factorization of a number.
 pub trait Factor {
     type FACTORS;

--- a/malachite-base/tests/lib.rs
+++ b/malachite-base/tests/lib.rs
@@ -397,6 +397,7 @@ pub mod num {
     pub mod factorization {
         pub mod factor;
         pub mod is_prime;
+        pub mod is_square;
         pub mod prime_indicator_sequence;
         pub mod prime_indicator_sequence_less_than;
         pub mod prime_sieve;

--- a/malachite-base/tests/lib.rs
+++ b/malachite-base/tests/lib.rs
@@ -396,6 +396,7 @@ pub mod num {
     }
     pub mod factorization {
         pub mod factor;
+        pub mod is_perfect_power;
         pub mod is_prime;
         pub mod is_square;
         pub mod prime_indicator_sequence;

--- a/malachite-base/tests/num/factorization/is_perfect_power.rs
+++ b/malachite-base/tests/num/factorization/is_perfect_power.rs
@@ -1,0 +1,114 @@
+// Copyright © 2025 William Youmans
+//
+// This file is part of Malachite.
+//
+// Malachite is free software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License (LGPL) as published by the Free Software Foundation; either version
+// 3 of the License, or (at your option) any later version. See <https://www.gnu.org/licenses/>.
+
+use malachite_base::num::arithmetic::traits::CheckedSquare;
+use malachite_base::num::factorization::traits::{Factor, IsPerfectPower};
+use malachite_base::num::random::random_unsigned_bit_chunks;
+use malachite_base::random::EXAMPLE_SEED;
+
+const NUM_TESTS: usize = 1000;
+const BITS: u64 = 64;
+
+fn test_perfect_squares() {
+    // Test that squares pass the test
+    let iter = random_unsigned_bit_chunks::<u64>(EXAMPLE_SEED, BITS / 2).take(NUM_TESTS);
+    for d in iter {
+        if let Some(d_squared) = d.checked_square() {
+            let res = d_squared.is_perfect_power();
+            assert!(res.is_some());
+
+            let (base, exp) = res.unwrap();
+            assert_eq!(base.pow(exp), d_squared);
+        }
+    }
+}
+
+fn test_perfect_cubes() {
+    let iter = random_unsigned_bit_chunks::<u32>(EXAMPLE_SEED, BITS / 3).take(NUM_TESTS);
+    for d in iter {
+        if let Some(d_pow) = d.checked_pow(3) {
+            let res = d_pow.is_perfect_power();
+            assert!(res.is_some());
+
+            let (base, exp) = res.unwrap();
+            assert_eq!(base.pow(exp), d_pow);
+        }
+    }
+}
+
+fn test_perfect_fifth_powers() {
+    let iter = random_unsigned_bit_chunks::<u32>(EXAMPLE_SEED, BITS / 5).take(NUM_TESTS);
+    for d in iter {
+        if let Some(d_pow) = d.checked_pow(5) {
+            let res = d_pow.is_perfect_power();
+            assert!(res.is_some());
+
+            let (base, exp) = res.unwrap();
+            assert_eq!(base.pow(exp), d_pow);
+        }
+    }
+}
+
+fn test_exhaustive_other_powers() {
+    // Exhaustively test all other powers
+    // This tests all bases from 2 up to 2^(WORD_BITS/5) and all their powers
+    let max_base = 1u64 << (64 / 5); // Limit to prevent excessive test time
+
+    for d in 2..max_base {
+        let mut n = d * d; // Start with d^2
+
+        // Keep multiplying by d until we overflow
+        loop {
+            let result = n.is_perfect_power();
+
+            if let Some((base, exp)) = result {
+                assert_eq!(base.pow(exp), n);
+            }
+
+            // Try to multiply by d, break if overflow
+            match n.checked_mul(d) {
+                Some(next_n) => n = next_n,
+                None => break, // Overflow occurred
+            }
+        }
+    }
+}
+
+fn test_non_perfect_powers() {
+    let iter = random_unsigned_bit_chunks::<u64>(EXAMPLE_SEED, 64).take(NUM_TESTS);
+    for d in iter {
+        // naive perfect power testing by factoring
+        if d.factor().into_iter().count() != 1 {
+            assert!(d.is_perfect_power().is_none());
+        }
+    }
+}
+
+fn test_edge_cases() {
+    // non-perfect powers
+    let non_pows: [u64; 5] = [0, 1, 2, 3, 6];
+    for x in non_pows {
+        assert_eq!(x.is_perfect_power(), None);
+    }
+
+    let pows: [u64; 10] = [4, 8, 9, 16, 25, 32, 64, 81, 100, 128];
+    for x in pows {
+        let (base, exp) = x.is_perfect_power().unwrap();
+        assert_eq!(x, base.pow(exp));
+    }
+}
+
+#[test]
+fn test_is_perfect_power() {
+    test_perfect_squares();
+    test_perfect_cubes();
+    test_perfect_fifth_powers();
+    test_exhaustive_other_powers();
+    test_non_perfect_powers();
+    test_edge_cases();
+}

--- a/malachite-base/tests/num/factorization/is_square.rs
+++ b/malachite-base/tests/num/factorization/is_square.rs
@@ -1,0 +1,36 @@
+// Copyright © 2025 William Youmans
+//
+// Uses code adopted from the FLINT Library.
+//
+//      Copyright © 2009 William Hart
+//
+// This file is part of Malachite.
+//
+// Malachite is free software: you can redistribute it and/or modify it under the terms of the GNU
+// Lesser General Public License (LGPL as published by the Free Software Foundation; either version
+// 3 of the License, or (at your option any later version. See <https://www.gnu.org/licenses/>.
+
+use malachite_base::num::factorization::traits::IsSquare;
+use malachite_base::num::random::random_unsigned_bit_chunks;
+use malachite_base::random::EXAMPLE_SEED;
+
+const NUM_TESTS: usize = 1000;
+
+#[test]
+fn test_is_square() {
+    // Randomly generate integers in the range (a^2, (a+1)^2) which are guaranteed
+    // to not be square.
+    let iter_a = random_unsigned_bit_chunks::<u64>(EXAMPLE_SEED, 32).take(NUM_TESTS);
+    let iter_b = random_unsigned_bit_chunks::<u64>(EXAMPLE_SEED, 32).take(NUM_TESTS);
+    for (a, b) in iter_a.zip(iter_b) {
+        let s = a * a + (b % (2 * a)) + 1;
+        assert!(!s.is_square());
+    }
+
+    // Randomly generate squares
+    let iter_a = random_unsigned_bit_chunks::<u64>(EXAMPLE_SEED, 32).take(NUM_TESTS);
+    for a in iter_a {
+        let s = a * a;
+        assert!(s.is_square());
+    }
+}


### PR DESCRIPTION
This PR primarily adds the `IsSquare` and `IsPerfectPower` traits. FLINT `ulong_extras/is_square.c` was already implemented but I moved it into the trait implementation.  The `IsPerfectPower` trait is implemented for unsigned (positive) integers using the same algorithm used in FLINTs `ulong_extras/is_power.c`.

Comments:
1. I added tests for both implementations but am not sure how exactly to use the `test_utils` so I instead replicated FLINT's tests. 

2. I'm not 100% sure about the use of the 'Is' prefix in `IsPerfectPower/is_perfect_power`. The prefix `is` implies the output is a `bool`. But If the input `n` is a perfect power then we ought to return `a, b` such that `n = a^b`, since it is computed anyway.  So `is_perfect_power` returns an `Option` instead of a bool, with `None` interpreted as false and `Some((a, b))` interpreted as true, which is slightly counterintuitive. An alternative is to copy `IsSquare/SquareRoot` and have both `IsPerfectPower/PerfectRoot` but "perfect root" isn't a standard term as far as I'm aware. 