### PR TITLE
Fix malachite-nz no-std wide dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
 dependencies = [
  "bytemuck",
  "safe_arch",
+ "serde",
 ]
 
 [[package]]

--- a/malachite-nz/Cargo.toml
+++ b/malachite-nz/Cargo.toml
@@ -25,7 +25,7 @@ itertools = { version = "0.14.0", default-features = false, features = ["use_all
 libm = { version = "0.2.16", default-features = false }
 malachite-base = { version = "0.9.1", default-features = false, path = "../malachite-base" }
 serde = { version = "1.0.228", optional = true, default-features = false, features = ["alloc", "derive"] }
-wide = { version = "1.1.1" }
+wide = { version = "1.1.1", default-features = false }
 
 indoc = { version = "2.0.7", optional = true}
 pyo3 = { version = "0.27.2", optional = true }
@@ -43,11 +43,11 @@ pyo3-build-config = { version = "0.27.2", features = ["resolve-config"], optiona
 
 [features]
 default = ["std"]
-std = ["malachite-base/std"]
+std = ["malachite-base/std", "wide/std"]
 32_bit_limbs = []
 random = ["malachite-base/random"]
 enable_pyo3 = ["pyo3", "pyo3-build-config"]
-enable_serde = ["serde"]
+enable_serde = ["serde", "wide/serde"]
 test_build = ["malachite-base/test_build", "random", "serde", "serde_json", "num", "rug", "pyo3", "pyo3-build-config", "indoc"]
 bin_build = ["test_build"]
 float_helpers = []


### PR DESCRIPTION
Closes #97.

## Summary

- disables default features on the `wide` dependency in `malachite-nz`
- routes `wide/std` through the crate's `std` feature
- routes `wide/serde` through `enable_serde`

## Verification

```sh
cargo check --target thumbv7em-none-eabi --no-default-features -p malachite-nz --lib
```
