### PR TITLE
chore(nz): allow no-std usage

### DIFF
--- a/malachite-nz/Cargo.toml
+++ b/malachite-nz/Cargo.toml
@@ -25,7 +25,7 @@ itertools = { version = "0.14.0", default-features = false, features = ["use_all
 libm = { version = "0.2.16", default-features = false }
 malachite-base = { version = "0.9.1", default-features = false, path = "../malachite-base" }
 serde = { version = "1.0.228", optional = true, default-features = false, features = ["alloc", "derive"] }
-wide = { version = "1.1.1" }
+wide = { version = "1.1.1", default-features = false }
 
 indoc = { version = "2.0.7", optional = true}
 pyo3 = { version = "0.27.2", optional = true }
@@ -43,7 +43,7 @@ pyo3-build-config = { version = "0.27.2", features = ["resolve-config"], optiona
 
 [features]
 default = ["std"]
-std = ["malachite-base/std"]
+std = ["malachite-base/std", "wide/std"]
 32_bit_limbs = []
 random = ["malachite-base/random"]
 enable_pyo3 = ["pyo3", "pyo3-build-config"]


### PR DESCRIPTION
disables wide default features and route `malachite-nz/std` to `wide/std`.

wide enables std by default since 0.7.0, and `malachite-nz` started depending on it in 0.6.1 (968a7ba1f).

note: from my small investigation, `wide/std` only affects scalar fallbacks for floor, ceil, sqrt, and malachite-nz does not use these API, so there is no practical impacts for no std users.